### PR TITLE
refactor: consolidate shared page chrome imports into PageChromeBase.css

### DIFF
--- a/Packages/Pages/Agents/UI/Styles/Agents.css
+++ b/Packages/Pages/Agents/UI/Styles/Agents.css
@@ -25,24 +25,16 @@
   resize: vertical;
   resize: vertical;
 }
-.agents-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  animation: fadeIn 0.45s var(--ease-out-expo) 50ms both;
-}
 .agent-modal-body,
-.agents-scroll {
-  overflow-y: auto;
+#agent-modal-body {
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
 }
 .agents-scroll {
-  flex: 1;
-  padding: 32px 40px 60px;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 .agents-page-header {
   display: flex;
@@ -240,29 +232,6 @@
   line-height: 1.5;
   display: -webkit-box;
 }
-.agent-toggle {
-  flex-shrink: 0;
-  position: relative;
-  width: 40px;
-  height: 22px;
-}
-.agent-toggle input {
-  opacity: 0;
-  width: 0;
-  height: 0;
-  position: absolute;
-}
-.agent-toggle-track {
-  position: absolute;
-  inset: 0;
-  border-radius: 999px;
-  background: var(--bg-hover);
-  border: 1px solid var(--border);
-  cursor: pointer;
-  transition:
-    background 0.22s,
-    border-color 0.22s;
-}
 #agent-modal,
 .agent-model-select-wrap {
   position: relative;
@@ -272,28 +241,6 @@
 .agent-confirm-overlay {
   position: fixed;
   transition: opacity 0.18s;
-}
-.agent-toggle-track::after {
-  content: '';
-  position: absolute;
-  left: 3px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: var(--text-muted);
-  transition:
-    transform 0.22s var(--ease-spring),
-    background 0.22s;
-}
-.agent-toggle input:checked + .agent-toggle-track {
-  background: var(--accent);
-  border-color: var(--accent);
-}
-.agent-toggle input:checked + .agent-toggle-track::after {
-  transform: translateY(-50%) translateX(18px);
-  background: #fff;
 }
 .agent-model-badge {
   display: inline-flex;
@@ -835,8 +782,7 @@
 .agent-confirm-box h3 {
   color: var(--text-primary);
 }
-.agent-btn-cancel:hover,
-.agent-confirm-cancel:hover {
+.agent-btn-cancel:hover {
   background: var(--bg-hover);
 }
 .add-job-btn:disabled {
@@ -954,36 +900,9 @@
   margin-top: 8px;
   width: 100%;
 }
-.agent-confirm-cancel,
-.agent-confirm-delete {
-  flex: 1;
-  padding: 10px;
-  border-radius: 12px;
-  font-family: var(--font-ui);
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  border: 1px solid var(--border);
-  transition:
-    background var(--transition-fast),
-    transform var(--transition-fast);
-}
-.agent-confirm-cancel {
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-}
-.agent-confirm-delete {
-  background: rgba(220, 60, 60, 0.15);
-  border-color: rgba(220, 60, 60, 0.3);
-  color: #f87171;
-}
 .agent-card,
 .agent-model-badge {
   border: 1px solid var(--border);
-}
-.agent-confirm-delete:hover {
-  background: rgba(220, 60, 60, 0.25);
-  transform: translateY(-1px);
 }
 @keyframes fadeIn {
   from {

--- a/Packages/Pages/Agents/UI/Styles/AgentsPage.css
+++ b/Packages/Pages/Agents/UI/Styles/AgentsPage.css
@@ -1,14 +1,11 @@
 /* Shared page shell */
 @import '../../../Shared/Styles/PageShellBase.css';
-@import '../../../Shared/Styles/ThemePanel.css';
-@import '../../../Shared/Styles/PageSupportPanels.css';
-@import '../../../Shared/Styles/Library.css';
-@import '../../../Shared/Styles/About.css';
-@import '../../../Shared/Styles/ConnectorsAndMemory.css';
-@import '../../../Shared/Styles/Footer.css';
-@import '../../../Shared/Styles/ThemeTokens.css';
+@import '../../../Shared/Styles/PageChromeBase.css';
 
 /* Page-specific styles */
+@import '../../../Shared/Styles/PageContentBase.css';
+@import '../../../Shared/Styles/PageToggleBase.css';
+@import '../../../Shared/Styles/PageConfirmActions.css';
 @import '../../../Shared/Styles/PageTaglineBadge.css';
 @import './Agents.css';
 @import '../../../Shared/Styles/FreeConnectors.css';

--- a/Packages/Pages/Automations/UI/Styles/Automations.css
+++ b/Packages/Pages/Automations/UI/Styles/Automations.css
@@ -10,20 +10,6 @@
 .trigger-sub-inputs.hidden {
   display: none;
 }
-.automations-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  animation: fadeIn 0.45s var(--ease-out-expo) 50ms both;
-}
-.automations-scroll {
-  flex: 1;
-  overflow-y: auto;
-  padding: 32px 40px 60px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
-}
 .auto-page-header {
   display: flex;
   align-items: flex-end;
@@ -215,55 +201,10 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
-.auto-toggle {
-  flex-shrink: 0;
-  position: relative;
-  width: 40px;
-  height: 22px;
-}
-.auto-toggle input {
-  opacity: 0;
-  width: 0;
-  height: 0;
-  position: absolute;
-}
 .auto-card-btn svg,
 .auto-trigger-icon {
   height: 13px;
   width: 13px;
-}
-.auto-toggle-track {
-  position: absolute;
-  inset: 0;
-  border-radius: 999px;
-  background: var(--bg-hover);
-  border: 1px solid var(--border);
-  cursor: pointer;
-  transition:
-    background 0.22s,
-    border-color 0.22s;
-}
-.auto-toggle-track::after {
-  content: '';
-  position: absolute;
-  left: 3px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: var(--text-muted);
-  transition:
-    transform 0.22s var(--ease-spring),
-    background 0.22s;
-}
-.auto-toggle input:checked + .auto-toggle-track {
-  background: var(--accent);
-  border-color: var(--accent);
-}
-.auto-toggle input:checked + .auto-toggle-track::after {
-  transform: translateY(-50%) translateX(18px);
-  background: #fff;
 }
 .auto-card-meta {
   display: flex;
@@ -847,8 +788,7 @@
 .confirm-box h3 {
   color: var(--text-primary);
 }
-.auto-btn-cancel:hover,
-.confirm-cancel-btn:hover {
+.auto-btn-cancel:hover {
   background: var(--bg-hover);
 }
 .add-action-btn svg {
@@ -954,33 +894,6 @@
   gap: 10px;
   margin-top: 8px;
   width: 100%;
-}
-.confirm-cancel-btn,
-.confirm-delete-btn {
-  flex: 1;
-  padding: 10px;
-  border-radius: 12px;
-  font-family: var(--font-ui);
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  border: 1px solid var(--border);
-  transition:
-    background var(--transition-fast),
-    transform var(--transition-fast);
-}
-.confirm-cancel-btn {
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-}
-.confirm-delete-btn {
-  background: rgba(220, 60, 60, 0.15);
-  border-color: rgba(220, 60, 60, 0.3);
-  color: #f87171;
-}
-.confirm-delete-btn:hover {
-  background: rgba(220, 60, 60, 0.25);
-  transform: translateY(-1px);
 }
 @keyframes fadeIn {
   from {

--- a/Packages/Pages/Automations/UI/Styles/AutomationsPage.css
+++ b/Packages/Pages/Automations/UI/Styles/AutomationsPage.css
@@ -12,6 +12,9 @@
 
 /* Page-specific styles */
 @import '../../../Chat/UI/Styles/AgentLog.css';
+@import '../../../Shared/Styles/PageContentBase.css';
+@import '../../../Shared/Styles/PageToggleBase.css';
+@import '../../../Shared/Styles/PageConfirmActions.css';
 @import './Automations.css';
 @import '../../../Shared/Styles/PageTaglineBadge.css';
 @import '../../../Agents/UI/Styles/Agents.css';

--- a/Packages/Pages/Automations/UI/Styles/AutomationsPage.css
+++ b/Packages/Pages/Automations/UI/Styles/AutomationsPage.css
@@ -2,13 +2,7 @@
 @import '../../../Shared/Styles/PageShellBase.css';
 @import '../../../Chat/UI/Styles/ChatComposerBase.css';
 @import '../../../Chat/UI/Styles/ChatConversationBase.css';
-@import '../../../Shared/Styles/ThemePanel.css';
-@import '../../../Shared/Styles/Library.css';
-@import '../../../Shared/Styles/PageSupportPanels.css';
-@import '../../../Shared/Styles/Footer.css';
-@import '../../../Shared/Styles/About.css';
-@import '../../../Shared/Styles/ThemeTokens.css';
-@import '../../../Shared/Styles/ConnectorsAndMemory.css';
+@import '../../../Shared/Styles/PageChromeBase.css';
 
 /* Page-specific styles */
 @import '../../../Chat/UI/Styles/AgentLog.css';

--- a/Packages/Pages/Events/UI/Styles/Events.css
+++ b/Packages/Pages/Events/UI/Styles/Events.css
@@ -1,7 +1,9 @@
-.event-detail-body,
-.events-scroll {
+.event-detail-body {
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
+}
+.event-detail-body,
+.events-scroll {
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
 }
@@ -31,18 +33,6 @@
 #event-detail-backdrop.open #event-detail-modal,
 #events-confirm-backdrop.open .modal-panel {
   transform: translateY(0) scale(1);
-}
-.events-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  animation: fadeIn 0.45s var(--ease-out-expo) 50ms both;
-}
-.events-scroll {
-  flex: 1;
-  overflow-y: auto;
-  padding: 32px 40px 60px;
 }
 .events-page-header {
   display: flex;
@@ -110,67 +100,12 @@
   flex-shrink: 0;
   flex-wrap: wrap;
 }
-.events-filter-group {
-  display: flex;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-subtle);
-  border-radius: 20px;
-  padding: 3px;
-  gap: 2px;
-}
-.events-clear-btn,
-.events-filter-btn {
-  background: 0 0;
-  color: var(--text-muted);
-  font-family: var(--font-ui);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-}
-.events-filter-btn {
-  padding: 6px 13px;
-  border-radius: 20px;
-  border: none;
-  white-space: nowrap;
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast);
-}
-.events-filter-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text-secondary);
-}
-.events-filter-btn.active {
-  background: var(--accent);
-  color: #fff;
-}
-.events-clear-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 14px;
-  border-radius: 20px;
-  border: 1px solid var(--border);
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast),
-    border-color var(--transition-fast);
-}
 .event-detail-timestamp,
 .event-elapsed,
 .event-error-preview,
 .event-time,
 .events-stat-value {
   font-family: var(--font-mono);
-}
-.events-clear-btn:hover {
-  background: rgba(220, 60, 60, 0.09);
-  color: #f87171;
-  border-color: rgba(220, 60, 60, 0.25);
-}
-.events-clear-btn svg {
-  width: 13px;
-  height: 13px;
 }
 .events-stats-bar {
   display: flex;

--- a/Packages/Pages/Events/UI/Styles/EventsPage.css
+++ b/Packages/Pages/Events/UI/Styles/EventsPage.css
@@ -1,13 +1,9 @@
 /* Shared page shell */
 @import '../../../Shared/Styles/PageShellBase.css';
-@import '../../../Shared/Styles/ThemePanel.css';
-@import '../../../Shared/Styles/PageSupportPanels.css';
-@import '../../../Shared/Styles/Library.css';
-@import '../../../Shared/Styles/About.css';
-@import '../../../Shared/Styles/ConnectorsAndMemory.css';
-@import '../../../Shared/Styles/Footer.css';
-@import '../../../Shared/Styles/ThemeTokens.css';
+@import '../../../Shared/Styles/PageChromeBase.css';
 
 /* Page-specific styles */
+@import '../../../Shared/Styles/PageContentBase.css';
+@import '../../../Shared/Styles/PageSegmentedControls.css';
 @import './Events.css';
 @import '../../../Shared/Styles/FreeConnectors.css';

--- a/Packages/Pages/Lock/Lock.css
+++ b/Packages/Pages/Lock/Lock.css
@@ -1,8 +1,7 @@
 /* ─── Lock page — Joanium ─────────────────────────────────────────────────── */
 
 /* 1. Design tokens (themes + root variables) */
-@import '../Shared/Styles/Themes.css';
-@import '../Shared/Styles/Root.css';
+@import '../Shared/Styles/ThemeTokens.css';
 
 /* ─── Layout ─────────────────────────────────────────────────────────────── */
 

--- a/Packages/Pages/Marketplace/UI/Styles/Marketplace.css
+++ b/Packages/Pages/Marketplace/UI/Styles/Marketplace.css
@@ -1,20 +1,3 @@
-.marketplace-modal-body,
-.marketplace-scroll {
-  scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
-}
-.marketplace-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  animation: fadeIn 0.45s var(--ease-out-expo) 50ms both;
-}
-.marketplace-scroll {
-  flex: 1;
-  overflow-y: auto;
-  padding: 32px 40px 60px;
-}
 .marketplace-page-header {
   display: flex;
   align-items: flex-start;
@@ -405,48 +388,10 @@
   width: 100%;
   height: 1px;
 }
-#marketplace-modal-backdrop {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 32px;
-  background: rgba(8, 11, 18, 0.55);
-  backdrop-filter: blur(14px);
-  z-index: 400;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.22s;
-}
-#marketplace-modal-backdrop.open {
-  opacity: 1;
-  pointer-events: auto;
-}
 #marketplace-modal {
-  position: relative;
   width: min(820px, calc(100vw - 48px));
-  max-height: min(86vh, 820px);
-  display: flex;
-  flex-direction: column;
   background: var(--bg-secondary);
-  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
   border-radius: var(--radius-xl);
-  box-shadow: 0 32px 96px rgba(0, 0, 0, 0.35);
-  transform: translateY(20px) scale(0.96);
-  transition: transform 0.3s var(--ease-spring);
-  overflow: hidden;
-}
-#marketplace-modal-backdrop.open #marketplace-modal {
-  transform: translateY(0) scale(1);
-}
-.marketplace-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 22px 26px 18px;
-  border-bottom: 1px solid var(--border-subtle);
-  gap: 16px;
 }
 .marketplace-modal-title-group {
   display: flex;
@@ -461,11 +406,6 @@
   display: flex;
   align-items: center;
   gap: 10px;
-}
-.marketplace-modal-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: 24px 28px 32px;
 }
 .marketplace-modal-status {
   margin-bottom: 14px;
@@ -489,62 +429,8 @@
   border: 1px solid rgba(205, 76, 76, 0.22);
   color: #fca5a5;
 }
-.marketplace-modal-content {
-  font-size: 13.5px;
-  line-height: 1.8;
-  color: var(--text-primary);
-}
-.marketplace-modal-content h1 {
-  font-size: 20px;
-  font-weight: 600;
-  margin: 0 0 12px;
-}
-.marketplace-modal-content h2 {
-  font-size: 16px;
-  font-weight: 600;
-  margin: 20px 0 8px;
-}
-.marketplace-modal-content h3 {
-  font-size: 14px;
-  font-weight: 600;
-  margin: 16px 0 6px;
-  color: var(--text-secondary);
-}
-.marketplace-modal-content p {
-  margin-bottom: 12px;
-  color: var(--text-secondary);
-}
-.marketplace-modal-content li {
-  margin: 4px 0 4px 20px;
-  color: var(--text-secondary);
-}
-.marketplace-modal-content strong {
-  color: var(--text-primary);
-  font-weight: 600;
-}
-.marketplace-modal-content em {
-  color: var(--text-muted);
-}
-.marketplace-modal-content code {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-subtle);
-  padding: 2px 6px;
-  border-radius: 5px;
-}
 .marketplace-modal-content pre {
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  padding: 14px 16px;
-  overflow-x: auto;
-  margin: 12px 0;
-}
-.marketplace-modal-content pre code {
-  background: 0 0;
-  border: none;
-  padding: 0;
 }
 @keyframes marketplaceSpin {
   from {

--- a/Packages/Pages/Marketplace/UI/Styles/MarketplacePage.css
+++ b/Packages/Pages/Marketplace/UI/Styles/MarketplacePage.css
@@ -1,14 +1,10 @@
 /* Shared page shell */
 @import '../../../Shared/Styles/PageShellBase.css';
-@import '../../../Shared/Styles/ThemePanel.css';
-@import '../../../Shared/Styles/PageSupportPanels.css';
-@import '../../../Shared/Styles/Library.css';
-@import '../../../Shared/Styles/About.css';
-@import '../../../Shared/Styles/ConnectorsAndMemory.css';
-@import '../../../Shared/Styles/Footer.css';
-@import '../../../Shared/Styles/ThemeTokens.css';
+@import '../../../Shared/Styles/PageChromeBase.css';
 
 /* Page-specific styles */
+@import '../../../Shared/Styles/PageContentBase.css';
+@import '../../../Shared/Styles/DetailModalBase.css';
 @import '../../../Shared/Styles/PageTaglineBadge.css';
 @import '../../../Shared/Styles/SharedEmptyState.css';
 @import '../../../Shared/Styles/SharedSearchBarSkillsAndAgents.css';

--- a/Packages/Pages/Personas/UI/Styles/Personas.css
+++ b/Packages/Pages/Personas/UI/Styles/Personas.css
@@ -1,20 +1,3 @@
-.persona-modal-body,
-.personas-scroll {
-  scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
-}
-.personas-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  animation: fadeIn 0.45s var(--ease-out-expo) 50ms both;
-}
-.personas-scroll {
-  flex: 1;
-  overflow-y: auto;
-  padding: 32px 40px 60px;
-}
 .personas-page-header {
   display: flex;
   align-items: center;
@@ -389,54 +372,9 @@
   border-color: color-mix(in srgb, var(--accent) 30%, transparent);
   transform: translateY(-1px);
 }
-#persona-modal-backdrop {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 32px;
-  background: rgba(8, 11, 18, 0.55);
-  backdrop-filter: blur(14px);
-  z-index: 400;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.22s;
-}
-#persona-modal-backdrop.open {
-  opacity: 1;
-  pointer-events: auto;
-}
 #persona-modal {
-  position: relative;
   width: min(680px, calc(100vw - 48px));
-  max-height: min(86vh, 820px);
-  display: flex;
-  flex-direction: column;
-  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
   border-radius: 28px;
-  box-shadow: 0 32px 96px rgba(0, 0, 0, 0.35);
-  transform: translateY(20px) scale(0.96);
-  transition: transform 0.3s var(--ease-spring);
-  overflow: hidden;
-}
-#persona-modal-backdrop.open #persona-modal {
-  transform: translateY(0) scale(1);
-}
-.persona-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 22px 26px 18px;
-  border-bottom: 1px solid var(--border-subtle);
-  flex-shrink: 0;
-  gap: 16px;
-}
-.persona-modal-title-group {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 0;
 }
 .persona-modal-avatar {
   width: 36px;
@@ -455,80 +393,16 @@
   box-shadow: 0 6px 16px var(--accent-glow);
   overflow: hidden;
 }
-.persona-modal-name {
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text-primary);
-  letter-spacing: -0.2px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.persona-modal-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: 24px 28px 32px;
-}
-.persona-modal-content {
-  font-size: 13.5px;
-  line-height: 1.8;
-  color: var(--text-primary);
-}
-.persona-modal-content h1 {
-  font-size: 20px;
-  font-weight: 600;
-  margin: 0 0 12px;
-}
-.persona-modal-content h2 {
-  font-size: 16px;
-  font-weight: 600;
-  margin: 20px 0 8px;
-}
-.persona-modal-content h3 {
-  font-size: 14px;
-  font-weight: 600;
-  margin: 16px 0 6px;
-  color: var(--text-secondary);
-}
-.persona-modal-content p {
-  margin-bottom: 12px;
-  color: var(--text-secondary);
-}
 .persona-modal-content p:last-child {
   margin-bottom: 0;
 }
-.persona-modal-content li {
-  margin: 4px 0 4px 20px;
-  color: var(--text-secondary);
-}
-.persona-modal-content strong {
-  color: var(--text-primary);
-  font-weight: 600;
-}
 .persona-modal-content em {
   font-style: italic;
-  color: var(--text-muted);
-}
-.persona-modal-content code {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-subtle);
-  padding: 2px 6px;
-  border-radius: 5px;
 }
 .persona-modal-content pre {
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-subtle);
   border-radius: 12px;
-  padding: 14px 16px;
-  overflow-x: auto;
-  margin: 12px 0;
 }
 .persona-modal-content pre code {
-  background: 0 0;
-  border: none;
-  padding: 0;
   font-size: 12px;
   line-height: 1.7;
 }

--- a/Packages/Pages/Personas/UI/Styles/PersonasPage.css
+++ b/Packages/Pages/Personas/UI/Styles/PersonasPage.css
@@ -1,14 +1,10 @@
 /* Shared page shell */
 @import '../../../Shared/Styles/PageShellBase.css';
-@import '../../../Shared/Styles/ThemePanel.css';
-@import '../../../Shared/Styles/PageSupportPanels.css';
-@import '../../../Shared/Styles/Library.css';
-@import '../../../Shared/Styles/About.css';
-@import '../../../Shared/Styles/ConnectorsAndMemory.css';
-@import '../../../Shared/Styles/Footer.css';
-@import '../../../Shared/Styles/ThemeTokens.css';
+@import '../../../Shared/Styles/PageChromeBase.css';
 
 /* Page-specific styles */
+@import '../../../Shared/Styles/PageContentBase.css';
+@import '../../../Shared/Styles/DetailModalBase.css';
 @import '../../../Shared/Styles/PageTaglineBadge.css';
 @import '../../../Shared/Styles/SharedEmptyState.css';
 @import './Personas.css';

--- a/Packages/Pages/Setup/UI/Styles/SetupPage.css
+++ b/Packages/Pages/Setup/UI/Styles/SetupPage.css
@@ -1,11 +1,8 @@
-/* 1. Themes */
-@import '../../../Shared/Styles/Themes.css';
+/* 1. Theme tokens */
+@import '../../../Shared/Styles/ThemeTokens.css';
 
-/* 2. Root */
-@import '../../../Shared/Styles/Root.css';
-
-/* 3. Setup */
+/* 2. Setup */
 @import './Setup.css';
 
-/* 4. Footer */
+/* 3. Footer */
 @import '../../../Shared/Styles/Footer.css';

--- a/Packages/Pages/Shared/Styles/DetailModalBase.css
+++ b/Packages/Pages/Shared/Styles/DetailModalBase.css
@@ -1,0 +1,175 @@
+/* Shared detail modal shell used by catalog-style pages. */
+
+#marketplace-modal-backdrop,
+#persona-modal-backdrop,
+#skill-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  background: rgba(8, 11, 18, 0.55);
+  backdrop-filter: blur(14px);
+  z-index: 400;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.22s;
+}
+
+#marketplace-modal-backdrop.open,
+#persona-modal-backdrop.open,
+#skill-modal-backdrop.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+#marketplace-modal,
+#persona-modal,
+#skill-modal {
+  position: relative;
+  max-height: min(86vh, 820px);
+  display: flex;
+  flex-direction: column;
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  box-shadow: 0 32px 96px rgba(0, 0, 0, 0.35);
+  transform: translateY(20px) scale(0.96);
+  transition: transform 0.3s var(--ease-spring);
+  overflow: hidden;
+}
+
+#marketplace-modal-backdrop.open #marketplace-modal,
+#persona-modal-backdrop.open #persona-modal,
+#skill-modal-backdrop.open #skill-modal {
+  transform: translateY(0) scale(1);
+}
+
+.marketplace-modal-header,
+.persona-modal-header,
+.skill-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 22px 26px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+  gap: 16px;
+}
+
+.marketplace-modal-body,
+.persona-modal-body,
+.skill-modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px 28px 32px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.persona-modal-title-group,
+.skill-modal-title-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.persona-modal-name,
+.skill-modal-name {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.marketplace-modal-content,
+.persona-modal-content,
+.skill-modal-content {
+  font-size: 13.5px;
+  line-height: 1.8;
+  color: var(--text-primary);
+}
+
+.marketplace-modal-content h1,
+.persona-modal-content h1,
+.skill-modal-content h1 {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0 0 12px;
+}
+
+.marketplace-modal-content h2,
+.persona-modal-content h2,
+.skill-modal-content h2 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 20px 0 8px;
+}
+
+.marketplace-modal-content h3,
+.persona-modal-content h3,
+.skill-modal-content h3 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 16px 0 6px;
+  color: var(--text-secondary);
+}
+
+.marketplace-modal-content p,
+.persona-modal-content p,
+.skill-modal-content p {
+  margin-bottom: 12px;
+  color: var(--text-secondary);
+}
+
+.marketplace-modal-content li,
+.persona-modal-content li,
+.skill-modal-content li {
+  margin: 4px 0 4px 20px;
+  color: var(--text-secondary);
+}
+
+.marketplace-modal-content strong,
+.persona-modal-content strong,
+.skill-modal-content strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.marketplace-modal-content em,
+.persona-modal-content em,
+.skill-modal-content em {
+  color: var(--text-muted);
+}
+
+.marketplace-modal-content code,
+.persona-modal-content code,
+.skill-modal-content code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  padding: 2px 6px;
+  border-radius: 5px;
+}
+
+.marketplace-modal-content pre,
+.persona-modal-content pre,
+.skill-modal-content pre {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  padding: 14px 16px;
+  overflow-x: auto;
+  margin: 12px 0;
+}
+
+.marketplace-modal-content pre code,
+.persona-modal-content pre code,
+.skill-modal-content pre code {
+  background: 0 0;
+  border: none;
+  padding: 0;
+}

--- a/Packages/Pages/Shared/Styles/PageChromeBase.css
+++ b/Packages/Pages/Shared/Styles/PageChromeBase.css
@@ -1,0 +1,8 @@
+/* Shared page chrome reused by most non-chat pages. */
+@import './ThemePanel.css';
+@import './PageSupportPanels.css';
+@import './Library.css';
+@import './About.css';
+@import './ConnectorsAndMemory.css';
+@import './Footer.css';
+@import './ThemeTokens.css';

--- a/Packages/Pages/Shared/Styles/PageConfirmActions.css
+++ b/Packages/Pages/Shared/Styles/PageConfirmActions.css
@@ -1,0 +1,48 @@
+/* Shared confirm actions used by destructive management flows. */
+
+.agent-confirm-cancel,
+.agent-confirm-delete,
+.confirm-cancel-btn,
+.confirm-delete-btn,
+.usage-confirm-cancel,
+.usage-confirm-delete {
+  flex: 1;
+  padding: 10px;
+  border-radius: 12px;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.agent-confirm-cancel,
+.confirm-cancel-btn,
+.usage-confirm-cancel {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+}
+
+.agent-confirm-cancel:hover,
+.confirm-cancel-btn:hover,
+.usage-confirm-cancel:hover {
+  background: var(--bg-hover);
+}
+
+.agent-confirm-delete,
+.confirm-delete-btn,
+.usage-confirm-delete {
+  background: rgba(220, 60, 60, 0.15);
+  border-color: rgba(220, 60, 60, 0.3);
+  color: #f87171;
+}
+
+.agent-confirm-delete:hover,
+.confirm-delete-btn:hover,
+.usage-confirm-delete:hover {
+  background: rgba(220, 60, 60, 0.25);
+  transform: translateY(-1px);
+}

--- a/Packages/Pages/Shared/Styles/PageContentBase.css
+++ b/Packages/Pages/Shared/Styles/PageContentBase.css
@@ -1,0 +1,31 @@
+/* Shared page content containers reused by non-chat pages. */
+
+.agents-main,
+.automations-main,
+.events-main,
+.marketplace-main,
+.personas-main,
+.skills-main,
+.templates-page,
+.usage-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: fadeIn 0.45s var(--ease-out-expo) 50ms both;
+}
+
+.agents-scroll,
+.automations-scroll,
+.events-scroll,
+.marketplace-scroll,
+.personas-scroll,
+.skills-scroll,
+.templates-scroll,
+.usage-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px 40px 60px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}

--- a/Packages/Pages/Shared/Styles/PageSegmentedControls.css
+++ b/Packages/Pages/Shared/Styles/PageSegmentedControls.css
@@ -1,0 +1,73 @@
+/* Shared segmented controls used by analytics and event pages. */
+
+.events-filter-group,
+.usage-range-btns {
+  display: flex;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 20px;
+  padding: 3px;
+  gap: 2px;
+}
+
+.events-clear-btn,
+.events-filter-btn,
+.usage-clear-btn,
+.usage-range-btn {
+  background: 0 0;
+  color: var(--text-muted);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.events-filter-btn,
+.usage-range-btn {
+  padding: 6px 13px;
+  border-radius: 20px;
+  border: none;
+  white-space: nowrap;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.events-filter-btn:hover,
+.usage-range-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+.events-filter-btn.active,
+.usage-range-btn.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.events-clear-btn,
+.usage-clear-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.events-clear-btn:hover,
+.usage-clear-btn:hover {
+  background: rgba(220, 60, 60, 0.09);
+  color: #f87171;
+  border-color: rgba(220, 60, 60, 0.25);
+}
+
+.events-clear-btn svg,
+.usage-clear-btn svg {
+  width: 13px;
+  height: 13px;
+}

--- a/Packages/Pages/Shared/Styles/PageSegmentedControls.css
+++ b/Packages/Pages/Shared/Styles/PageSegmentedControls.css
@@ -47,7 +47,7 @@
 
 .events-clear-btn,
 .usage-clear-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 6px;
   padding: 8px 14px;

--- a/Packages/Pages/Shared/Styles/PageToggleBase.css
+++ b/Packages/Pages/Shared/Styles/PageToggleBase.css
@@ -1,0 +1,64 @@
+/* Shared toggle switches used by management pages. */
+
+.agent-toggle,
+.auto-toggle,
+.skill-toggle {
+  flex-shrink: 0;
+  position: relative;
+  width: 40px;
+  height: 22px;
+}
+
+.agent-toggle input,
+.auto-toggle input,
+.skill-toggle-input {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+}
+
+.agent-toggle-track,
+.auto-toggle-track,
+.skill-toggle-track {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition:
+    background 0.22s,
+    border-color 0.22s;
+}
+
+.agent-toggle-track::after,
+.auto-toggle-track::after,
+.skill-toggle-track::after {
+  content: '';
+  position: absolute;
+  left: 3px;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transform: translateY(-50%);
+  transition:
+    transform 0.22s var(--ease-spring),
+    background 0.22s;
+}
+
+.agent-toggle input:checked + .agent-toggle-track,
+.auto-toggle input:checked + .auto-toggle-track,
+.skill-toggle-input:checked + .skill-toggle-track {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.agent-toggle input:checked + .agent-toggle-track::after,
+.auto-toggle input:checked + .auto-toggle-track::after,
+.skill-toggle-input:checked + .skill-toggle-track::after {
+  transform: translateY(-50%) translateX(18px);
+  background: #fff;
+}

--- a/Packages/Pages/Skills/UI/Styles/Skills.css
+++ b/Packages/Pages/Skills/UI/Styles/Skills.css
@@ -4,26 +4,6 @@
   cursor: pointer;
 }
 
-.skill-modal-body,
-.skills-scroll {
-  scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
-}
-
-.skills-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  animation: fadeIn 0.45s var(--ease-out-expo) 50ms both;
-}
-
-.skills-scroll {
-  flex: 1;
-  overflow-y: auto;
-  padding: 32px 40px 60px;
-}
-
 .skills-page-header {
   display: flex;
   align-items: flex-start;
@@ -294,62 +274,13 @@
 }
 
 .skill-toggle {
-  position: relative;
-  width: 40px;
-  height: 22px;
-  flex-shrink: 0;
   cursor: pointer;
   z-index: 2;
 }
 
-.skill-toggle-input {
-  opacity: 0;
-  width: 0;
-  height: 0;
-  position: absolute;
-}
-
-.skill-toggle-track {
-  position: absolute;
-  inset: 0;
-  border-radius: 999px;
-  background: var(--bg-hover);
-  border: 1px solid var(--border);
-  cursor: pointer;
-  transition:
-    background 0.22s,
-    border-color 0.22s;
-}
-
-.skill-toggle-track::after {
-  content: '';
-  position: absolute;
-  left: 3px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: var(--text-muted);
-  transition:
-    transform 0.22s var(--ease-spring),
-    background 0.22s;
-}
-
-.skill-modal-content code,
 .skill-trigger {
   border: 1px solid var(--border-subtle);
   background: var(--bg-tertiary);
-}
-
-.skill-toggle-input:checked + .skill-toggle-track {
-  background: var(--accent);
-  border-color: var(--accent);
-}
-
-.skill-toggle-input:checked + .skill-toggle-track::after {
-  transform: translateY(-50%) translateX(18px);
-  background: #fff;
 }
 
 .skill-trigger {
@@ -458,59 +389,9 @@
   transform: translateY(-1px);
 }
 
-#skill-modal-backdrop {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 32px;
-  background: rgba(8, 11, 18, 0.55);
-  backdrop-filter: blur(14px);
-  z-index: 400;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.22s;
-}
-
-#skill-modal-backdrop.open {
-  opacity: 1;
-  pointer-events: auto;
-}
-
 #skill-modal {
-  position: relative;
   width: min(720px, calc(100vw - 48px));
-  max-height: min(86vh, 820px);
-  display: flex;
-  flex-direction: column;
-  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
   border-radius: 28px;
-  box-shadow: 0 32px 96px rgba(0, 0, 0, 0.35);
-  transform: translateY(20px) scale(0.96);
-  transition: transform 0.3s var(--ease-spring);
-  overflow: hidden;
-}
-
-#skill-modal-backdrop.open #skill-modal {
-  transform: translateY(0) scale(1);
-}
-
-.skill-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 22px 26px 18px;
-  border-bottom: 1px solid var(--border-subtle);
-  flex-shrink: 0;
-  gap: 16px;
-}
-
-.skill-modal-title-group {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 0;
 }
 
 .skill-modal-icon {
@@ -529,91 +410,19 @@
   height: 17px;
 }
 
-.skill-modal-name {
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text-primary);
-  letter-spacing: -0.2px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.skill-modal-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: 24px 28px 32px;
-}
-
-.skill-modal-content {
-  font-size: 13.5px;
-  line-height: 1.8;
-  color: var(--text-primary);
-}
-
-.skill-modal-content h1 {
-  font-size: 20px;
-  font-weight: 600;
-  margin: 0 0 12px;
-}
-
-.skill-modal-content h2 {
-  font-size: 16px;
-  font-weight: 600;
-  margin: 20px 0 8px;
-}
-
-.skill-modal-content h3 {
-  font-size: 14px;
-  font-weight: 600;
-  margin: 16px 0 6px;
-  color: var(--text-secondary);
-}
-
-.skill-modal-content p {
-  margin-bottom: 12px;
-  color: var(--text-secondary);
-}
-
 .skill-modal-content p:last-child {
   margin-bottom: 0;
 }
 
-.skill-modal-content li {
-  margin: 4px 0 4px 20px;
-  color: var(--text-secondary);
-}
-
-.skill-modal-content strong {
-  color: var(--text-primary);
-  font-weight: 600;
-}
-
 .skill-modal-content em {
   font-style: italic;
-  color: var(--text-muted);
-}
-
-.skill-modal-content code {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  padding: 2px 6px;
-  border-radius: 5px;
 }
 
 .skill-modal-content pre {
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-subtle);
   border-radius: 12px;
-  padding: 14px 16px;
-  overflow-x: auto;
-  margin: 12px 0;
 }
 
 .skill-modal-content pre code {
-  background: 0 0;
-  border: none;
-  padding: 0;
   font-size: 12px;
   line-height: 1.7;
 }

--- a/Packages/Pages/Skills/UI/Styles/SkillsPage.css
+++ b/Packages/Pages/Skills/UI/Styles/SkillsPage.css
@@ -1,14 +1,11 @@
 /* Shared page shell */
 @import '../../../Shared/Styles/PageShellBase.css';
-@import '../../../Shared/Styles/ThemePanel.css';
-@import '../../../Shared/Styles/PageSupportPanels.css';
-@import '../../../Shared/Styles/Library.css';
-@import '../../../Shared/Styles/About.css';
-@import '../../../Shared/Styles/ConnectorsAndMemory.css';
-@import '../../../Shared/Styles/Footer.css';
-@import '../../../Shared/Styles/ThemeTokens.css';
+@import '../../../Shared/Styles/PageChromeBase.css';
 
 /* Page-specific styles */
+@import '../../../Shared/Styles/PageContentBase.css';
+@import '../../../Shared/Styles/PageToggleBase.css';
+@import '../../../Shared/Styles/DetailModalBase.css';
 @import '../../../Shared/Styles/PageTaglineBadge.css';
 @import '../../../Shared/Styles/SharedEmptyState.css';
 @import './Skills.css';

--- a/Packages/Pages/Templates/UI/Styles/Templates.css
+++ b/Packages/Pages/Templates/UI/Styles/Templates.css
@@ -3,24 +3,14 @@
 /* ── Page shell ──────────────────────────────────────────────────────────── */
 
 .templates-page {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
   width: 100%;
   height: 100%;
   min-width: 0;
   min-height: 0;
-  animation: fadeIn 0.45s var(--ease-out-expo) 50ms both;
 }
 
 .templates-scroll {
-  flex: 1;
-  overflow-y: auto;
   overflow-x: hidden;
-  padding: 32px 40px 60px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
 }
 
 /* ── Search wrapper ─────────────────────────────────────────────────────── */

--- a/Packages/Pages/Templates/UI/Styles/TemplatesPage.css
+++ b/Packages/Pages/Templates/UI/Styles/TemplatesPage.css
@@ -1,16 +1,9 @@
 /* Shared page shell */
 @import '../../../Shared/Styles/PageShellBase.css';
-@import '../../../Shared/Styles/ThemePanel.css';
-@import '../../../Shared/Styles/PageSupportPanels.css';
-@import '../../../Shared/Styles/Library.css';
-@import '../../../Shared/Styles/About.css';
-@import '../../../Shared/Styles/ConnectorsAndMemory.css';
-@import '../../../Shared/Styles/Footer.css';
-@import '../../../Shared/Styles/ThemeTokens.css';
+@import '../../../Shared/Styles/PageChromeBase.css';
 
 /* Page-specific styles */
+@import '../../../Shared/Styles/PageContentBase.css';
 @import '../../../Shared/Styles/PageTaglineBadge.css';
-@import '../../../Shared/Styles/SharedEmptyState.css';
-@import '../../../Shared/Styles/SharedSearchBarSkillsAndAgents.css';
 @import '../../../Shared/Styles/FreeConnectors.css';
 @import './Templates.css';

--- a/Packages/Pages/Usage/UI/Styles/Usage.css
+++ b/Packages/Pages/Usage/UI/Styles/Usage.css
@@ -4,10 +4,13 @@
   text-transform: uppercase;
 }
 
-.activity-list,
-.usage-scroll {
+.activity-list {
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
+}
+
+.activity-list,
+.usage-scroll {
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
 }
@@ -16,20 +19,6 @@
 .model-row-name {
   white-space: nowrap;
   text-overflow: ellipsis;
-}
-
-.usage-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  animation: fadeIn 0.45s var(--ease-out-expo) 50ms both;
-}
-
-.usage-scroll {
-  flex: 1;
-  overflow-y: auto;
-  padding: 32px 40px 60px;
 }
 
 .usage-page-header {
@@ -99,25 +88,6 @@
   flex-wrap: wrap;
 }
 
-.usage-range-btns {
-  display: flex;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-subtle);
-  border-radius: 20px;
-  padding: 3px;
-  gap: 2px;
-}
-
-.usage-clear-btn,
-.usage-range-btn {
-  background: 0 0;
-  color: var(--text-muted);
-  font-family: var(--font-ui);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-}
-
 .activity-cost,
 .activity-tokens,
 .provider-cost,
@@ -125,39 +95,6 @@
 .usage-card-value,
 .usage-section-meta {
   font-family: var(--font-mono);
-}
-
-.usage-range-btn {
-  padding: 6px 13px;
-  border-radius: 20px;
-  border: none;
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast);
-  white-space: nowrap;
-}
-
-.usage-range-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text-secondary);
-}
-
-.usage-range-btn.active {
-  background: var(--accent);
-  color: #fff;
-}
-
-.usage-clear-btn {
-  padding: 8px 14px;
-  border-radius: 20px;
-  border: 1px solid var(--border);
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast),
-    border-color var(--transition-fast);
-  display: flex;
-  align-items: center;
-  gap: 6px;
 }
 
 .usage-card-icon,
@@ -169,17 +106,6 @@
 .usage-section {
   border: 1px solid var(--border-subtle);
   flex-direction: column;
-}
-
-.usage-clear-btn:hover {
-  background: rgba(220, 60, 60, 0.09);
-  color: #f87171;
-  border-color: rgba(220, 60, 60, 0.25);
-}
-
-.usage-clear-btn svg {
-  width: 13px;
-  height: 13px;
 }
 
 .usage-summary-grid {
@@ -596,41 +522,6 @@
   gap: 10px;
   width: 100%;
   margin-top: 4px;
-}
-
-.usage-confirm-cancel,
-.usage-confirm-delete {
-  flex: 1;
-  padding: 10px;
-  border-radius: 12px;
-  font-family: var(--font-ui);
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  border: 1px solid var(--border);
-  transition:
-    background var(--transition-fast),
-    transform var(--transition-fast);
-}
-
-.usage-confirm-cancel {
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-}
-
-.usage-confirm-cancel:hover {
-  background: var(--bg-hover);
-}
-
-.usage-confirm-delete {
-  background: rgba(220, 60, 60, 0.15);
-  border-color: rgba(220, 60, 60, 0.3);
-  color: #f87171;
-}
-
-.usage-confirm-delete:hover {
-  background: rgba(220, 60, 60, 0.25);
-  transform: translateY(-1px);
 }
 
 @keyframes fadeIn {

--- a/Packages/Pages/Usage/UI/Styles/Usage.css
+++ b/Packages/Pages/Usage/UI/Styles/Usage.css
@@ -370,9 +370,9 @@
   gap: 0;
   max-height: 320px;
   overflow-y: auto;
+  overflow-x: hidden;
   border-radius: 12px;
   border: 1px solid var(--border-subtle);
-  overflow: hidden;
 }
 
 .activity-item {

--- a/Packages/Pages/Usage/UI/Styles/UsagePage.css
+++ b/Packages/Pages/Usage/UI/Styles/UsagePage.css
@@ -1,14 +1,11 @@
 /* Shared page shell */
 @import '../../../Shared/Styles/PageShellBase.css';
-@import '../../../Shared/Styles/ThemePanel.css';
-@import '../../../Shared/Styles/PageSupportPanels.css';
-@import '../../../Shared/Styles/Library.css';
-@import '../../../Shared/Styles/About.css';
-@import '../../../Shared/Styles/ConnectorsAndMemory.css';
-@import '../../../Shared/Styles/Footer.css';
-@import '../../../Shared/Styles/ThemeTokens.css';
+@import '../../../Shared/Styles/PageChromeBase.css';
 
 /* Page-specific styles */
+@import '../../../Shared/Styles/PageContentBase.css';
+@import '../../../Shared/Styles/PageSegmentedControls.css';
+@import '../../../Shared/Styles/PageConfirmActions.css';
 @import '../../../Shared/Styles/PageTaglineBadge.css';
 @import './Usage.css';
 @import '../../../Shared/Styles/FreeConnectors.css';


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

## Related Issue

<!-- Link to the issue this PR addresses, e.g., Fixes #123 -->

## Type of Change

- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ x] My code follows the existing code style
- [ x] I have run `npm run lint` and it passes
- [ x] I have tested my changes locally
- [ ] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared styling components for modals, toggle switches, confirmation buttons, and page layouts into reusable base stylesheets across multiple pages.
  * Reorganized stylesheet dependencies to improve code maintainability and consistency throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->